### PR TITLE
add build arg to support proper versioning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:18.04
 
-ENV TERRAFORM_VERSION=0.13.4
+ARG TERRAFORM_VERSION
 
 RUN apt-get update && apt-get install jq wget zip gpg -y && \
     #include libc6-compat as a dep https://github.com/pulumi/pulumi/issues/1986

--- a/README.md
+++ b/README.md
@@ -13,5 +13,14 @@ Currently, this image is hosted on [Dockerhub](https://hub.docker.com/repository
 ## How to build image
 
 ```bash
-docker build .
+docker build . --build-arg "TERRAFORM_VERSION=*terraform-version*"
+```
+
+e.g.
+
+```bash
+docker build . --build-arg "TERRAFORM_VERSION=1.0.4" -t zipnz/az-terraform:latest
+docker build . --build-arg "TERRAFORM_VERSION=0.14.1" -t zipnz/az-terraform:0.14.1
+docker build . --build-arg "TERRAFORM_VERSION=0.13.4" -t zipnz/az-terraform:0.13.4
+...
 ```


### PR DESCRIPTION
Currently, we're in a wacky state where tf 0.13.4 actually is tagged as latest, while newer versions have explicit version tags.

This PR adds a build arg to allow build args to be specified at build time. As a side note, i've also refactored the way we tag builds i.e.

:latest points to a newer version of terraform
:0.14.1 points to tf 0.14.1
:0.13.4 points to tf 0.13.4 
etc
etc